### PR TITLE
Fix errors with creating outline view

### DIFF
--- a/Extensions/Outline/Outline.py
+++ b/Extensions/Outline/Outline.py
@@ -77,16 +77,14 @@ class Outline(QtGui.QTreeWidget):
                                         QtGui.QIcon(os.path.join("Resources", "images", "function")))
                     self.addTopLevelItem(functionItem)
             elif obj.objectType == "Function":
-               # obj.name, obj.lineno
-                methods = sorted(obj.methods.items(), key=itemgetter(1))
-                for name, lineno in methods:
-                    print("  def", name, lineno)
-                    functionItem = QtGui.QTreeWidgetItem()
-                    functionItem.setText(0, name)
-                    functionItem.setData(0, 3, lineno)
-                    functionItem.setIcon(0,
-                                        QtGui.QIcon(os.path.join("Resources", "images", "function")))
-                    self.addTopLevelItem(functionItem)
+                # obj.name, obj.lineno
+                #print("  def", obj.name, obj.lineno)
+                functionItem = QtGui.QTreeWidgetItem()
+                functionItem.setText(0, obj.name)
+                functionItem.setData(0, 3, obj.lineno)
+                functionItem.setIcon(0,
+                                    QtGui.QIcon(os.path.join("Resources", "images", "function")))
+                self.addTopLevelItem(functionItem)
 
         if len(outlineDict) == 0:
             item = QtGui.QTreeWidgetItem()


### PR DESCRIPTION
Pcode was spewing out tonnes of errors like this when I defined a top-level function:

```
Traceback (most recent call last):
  File "/home/takluyver/Code/Pcode/Extensions/Outline/Outline.py", line 81, in updateOutline
    methods = sorted(obj.methods.items(), key=itemgetter(1))
AttributeError: 'Function' object has no attribute 'methods'
```

This fixes that. It still produces TokenErrors when I'm half-way through typing a line, but that's a separate issue.
