### PR TITLE
Exit out cleanly if the user launches with Python < 3

### DIFF
--- a/Pcode.py
+++ b/Pcode.py
@@ -1,5 +1,12 @@
 import sys
 import os
+import logging
+
+logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s')
+if sys.version_info.major < 3:
+    logging.error("This application requires Python 3")
+    sys.exit(1)
+
 from PyQt4 import QtCore, QtGui
 
 from Extensions.UseData import UseData


### PR DESCRIPTION
- Rather than futz about with different 'print' syntax, just
  setup a logger, print a useful message, and exit with a non-zero status
