### PR TITLE
Flush top pull-down tool sheets to the tab bar

### DIFF
--- a/Extensions/StyleSheet.py
+++ b/Extensions/StyleSheet.py
@@ -575,7 +575,7 @@ _MAIN_MENU_TEMPLATE = Template("""
 
 _TOOL_WIDGET_TEMPLATE = Template("""
         QLabel#containerLabel {
-            border-top: 2px solid $accent;
+            border-top: none;
             border-left: 1px solid $border;
             border-right: 1px solid $border;
             border-bottom: 1px solid $border;


### PR DESCRIPTION
﻿## Summary
- Top pull-down sheets (Run Parameters, Favourites, etc.) no longer sit below a hard-coded 22/24px gap.
- Overlay top margin tracks the real tab bar height; tool-widget layouts have zero spacing.
- containerLabel stylesheet sets border-top: none explicitly for the hang-from-top look.
- Smoke test test_tool_sheet_alignment checks flush geometry.

## Test plan
- [x] pytest unit suite (not slow and not smoke)
- [x] pytest smoke suite (not slow)
- [ ] Manual: open Run Parameters / Favourites — sheet top flush under tabs, no gray strip
