### PR TITLE
Improve Run Parameters sheet layout and top alignment

### DIFF
--- a/Extensions/BottomWidgets/RunWidget.py
+++ b/Extensions/BottomWidgets/RunWidget.py
@@ -5,12 +5,12 @@ import locale
 from PyQt6.Qsci import QsciScintilla, QsciScintillaBase, QsciLexerCustom
 from PyQt6.QtCore import (
     QByteArray, QCoreApplication, QIODevice, QProcess, QProcessEnvironment,
-    Qt, pyqtSignal,
+    QSize, Qt, pyqtSignal,
 )
 from PyQt6.QtGui import QAction, QColor, QIcon, QPalette
 from PyQt6.QtWidgets import (
-    QCheckBox, QComboBox, QHBoxLayout, QLabel, QMenu, QMessageBox, QSpinBox,
-    QToolButton, QVBoxLayout,
+    QCheckBox, QComboBox, QHBoxLayout, QLabel, QMenu, QMessageBox,
+    QSizePolicy, QSpinBox, QToolButton, QVBoxLayout, QWidget,
 )
 
 from Extensions.settings_utils import to_bool, from_bool
@@ -27,7 +27,10 @@ class SetRunParameters(QLabel):
     def __init__(self, projectSettings, projectPathDict, useData, parent=None):
         QLabel.__init__(self, parent)
 
-        self.setMinimumSize(400, 220)
+        # QLabel ignores its layout in sizeHint(); height comes from overrides.
+        self.setMinimumWidth(480)
+        self.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum)
 
         self.setBackgroundRole(QPalette.ColorRole.Window)
         self.setAutoFillBackground(True)
@@ -39,25 +42,24 @@ class SetRunParameters(QLabel):
         self.projectPathDict = projectPathDict
 
         mainLayout = QVBoxLayout()
+        mainLayout.setContentsMargins(12, 10, 12, 12)
+        mainLayout.setSpacing(10)
 
-        hbox = QHBoxLayout()
-        mainLayout.addLayout(hbox)
-
-        label = QLabel("Run Parameters")
-        label.setObjectName("toolWidgetNameLabel")
-        hbox.addWidget(label)
-
-        hbox.addStretch(1)
-
+        header = QHBoxLayout()
+        title = QLabel("Run Parameters")
+        title.setObjectName("toolWidgetNameLabel")
+        header.addWidget(title)
+        header.addStretch(1)
         self.hideButton = QToolButton()
         self.hideButton.setAutoRaise(True)
         self.hideButton.setIcon(
             QIcon(os.path.join("Resources", "images", "cross_")))
         self.hideButton.clicked.connect(self.hide)
-        hbox.addWidget(self.hideButton)
+        header.addWidget(self.hideButton)
+        mainLayout.addLayout(header)
 
-        hbox = QHBoxLayout()
-        mainLayout.addLayout(hbox)
+        # --- Run ---
+        mainLayout.addWidget(self._section("Run"))
 
         self.runTypeBox = QComboBox()
         self.runTypeBox.addItem("Run")
@@ -72,7 +74,7 @@ class SetRunParameters(QLabel):
             self.runTypeBox.setCurrentIndex(3)
         self.runTypeBox.currentIndexChanged.connect(self.saveArguments)
         self.runTypeBox.currentIndexChanged.connect(self.runTypeChanged)
-        hbox.addWidget(self.runTypeBox)
+        mainLayout.addLayout(self._labeled_row("Mode", self.runTypeBox))
 
         self.traceTypeBox = QComboBox()
         self.traceTypeBox.addItem("Calling relationships")
@@ -82,42 +84,46 @@ class SetRunParameters(QLabel):
         self.traceTypeBox.setCurrentIndex(int(
             self.projectSettings["TraceType"]))
         self.traceTypeBox.currentIndexChanged.connect(self.saveArguments)
-        hbox.addWidget(self.traceTypeBox)
-
+        mainLayout.addWidget(self.traceTypeBox)
         if self.runTypeBox.currentIndex() != 2:
             self.traceTypeBox.hide()
 
-        self.runWithArgsBox = QCheckBox("Arguments:")
+        self.runWithArgsBox = QCheckBox("Pass arguments")
         if to_bool(self.projectSettings["RunWithArguments"]):
             self.runWithArgsBox.setChecked(True)
-        self.runWithArgsBox.toggled.connect(self.saveArguments)
+        self.runWithArgsBox.toggled.connect(self._argsToggled)
         mainLayout.addWidget(self.runWithArgsBox)
 
+        argsWrap = QWidget()
+        argsWrap.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        argsLayout = QHBoxLayout(argsWrap)
+        argsLayout.setContentsMargins(18, 0, 0, 0)
+        argsLayout.setSpacing(0)
         self.argumentsLine = PathLineEdit()
+        self.argumentsLine.setPlaceholderText("Optional arguments…")
         self.argumentsLine.setText(self.projectSettings["RunArguments"])
         self.argumentsLine.textChanged.connect(self.saveArguments)
-        mainLayout.addWidget(self.argumentsLine)
+        argsLayout.addWidget(self.argumentsLine)
+        mainLayout.addWidget(argsWrap)
+        self.argumentsLine.setEnabled(self.runWithArgsBox.isChecked())
 
-        hbox = QHBoxLayout()
-
-        self.clearOutputBox = QCheckBox("Clear Output Window")
+        self.clearOutputBox = QCheckBox("Clear output")
         if to_bool(self.projectSettings["ClearOutputWindowOnRun"]):
             self.clearOutputBox.setChecked(True)
         self.clearOutputBox.toggled.connect(self.saveArguments)
-        hbox.addWidget(self.clearOutputBox)
-
-        hbox.addStretch(1)
-
-        hbox.addWidget(QLabel("Max Output Size <lines>"))
+        mainLayout.addWidget(self.clearOutputBox)
 
         self.bufferSizeBox = QSpinBox()
         self.bufferSizeBox.setMaximum(999)
-        self.bufferSizeBox.setMinimumWidth(100)
+        self.bufferSizeBox.setMinimumWidth(90)
         self.bufferSizeBox.setValue(int(self.projectSettings['BufferSize']))
         self.bufferSizeBox.valueChanged.connect(self.saveArguments)
-        hbox.addWidget(self.bufferSizeBox)
+        mainLayout.addLayout(
+            self._labeled_row("Max lines", self.bufferSizeBox, stretch=False))
 
-        mainLayout.addLayout(hbox)
+        # --- Console ---
+        mainLayout.addWidget(self._section("Console"))
 
         self.runPointBox = QComboBox()
         self.runPointBox.addItem("Internal Console")
@@ -125,38 +131,82 @@ class SetRunParameters(QLabel):
         if not to_bool(self.projectSettings["RunInternal"]):
             self.runPointBox.setCurrentIndex(1)
         self.runPointBox.currentIndexChanged.connect(self.saveArguments)
-        mainLayout.addWidget(self.runPointBox)
+        mainLayout.addLayout(self._labeled_row("Target", self.runPointBox))
 
-        self.useVirtualEnvBox = QCheckBox("Use Virtual Environment")
+        self.useVirtualEnvBox = QCheckBox("Use virtual environment")
         if to_bool(self.projectSettings["UseVirtualEnv"]):
             self.useVirtualEnvBox.setChecked(True)
         self.useVirtualEnvBox.toggled.connect(self.setDefaultInterpreter)
         mainLayout.addWidget(self.useVirtualEnvBox)
 
-        self.debugWaitBox = QCheckBox("Wait for debugger to attach")
+        self.debugWaitBox = QCheckBox("Wait for debugger")
         if to_bool(self.projectSettings.get("DebugWait")):
             self.debugWaitBox.setChecked(True)
         self.debugWaitBox.toggled.connect(self.saveArguments)
         mainLayout.addWidget(self.debugWaitBox)
 
-        hbox = QHBoxLayout()
-        mainLayout.addLayout(hbox)
-
-        label = QLabel("Python Interpreter")
-        hbox.addWidget(label)
-        
-        hbox.addStretch(1)
-
+        # --- Interpreter ---
+        mainLayout.addWidget(self._section("Interpreter"))
         self.installedPythonVersionBox = QComboBox()
-        self.installedPythonVersionBox.setMinimumWidth(200)
+        self.installedPythonVersionBox.setMinimumWidth(280)
         self.updateInstalledInterpreters()
         self.installedPythonVersionBox.currentIndexChanged.connect(
             self.setDefaultInterpreter)
-        hbox.addWidget(self.installedPythonVersionBox)
+        mainLayout.addLayout(
+            self._labeled_row("Python", self.installedPythonVersionBox))
 
         self.setLayout(mainLayout)
-
         self.setDefaultInterpreter()
+
+    def sizeHint(self):
+        lay = self.layout()
+        if lay is not None:
+            hint = lay.sizeHint()
+            return QSize(max(480, hint.width()), hint.height())
+        return QLabel.sizeHint(self)
+
+    def minimumSizeHint(self):
+        lay = self.layout()
+        if lay is not None:
+            hint = lay.minimumSize()
+            return QSize(max(480, hint.width()), hint.height())
+        return QLabel.minimumSizeHint(self)
+
+    def showEvent(self, event):
+        QLabel.showEvent(self, event)
+        # Parent overlay may have sized us from QLabel's bogus hint; grow now.
+        self.updateGeometry()
+        self.adjustSize()
+
+    def _section(self, text):
+        label = QLabel(text)
+        label.setObjectName("toolWidgetSectionLabel")
+        label.setSizePolicy(
+            QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
+        return label
+
+    def _field_label(self, text):
+        label = QLabel(text)
+        label.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+        label.setSizePolicy(
+            QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+        return label
+
+    def _labeled_row(self, text, widget, stretch=True):
+        row = QHBoxLayout()
+        row.setSpacing(10)
+        row.addWidget(self._field_label(text))
+        if stretch:
+            row.addWidget(widget, 1)
+        else:
+            row.addWidget(widget)
+            row.addStretch(1)
+        return row
+
+    def _argsToggled(self, checked):
+        self.argumentsLine.setEnabled(checked)
+        self.saveArguments()
 
     def updateInstalledInterpreters(self):
         self.installedPythonVersionBox.clear()
@@ -190,9 +240,13 @@ class SetRunParameters(QLabel):
             self.runPointBox.currentIndex() == 0)
         self.projectSettings["TraceType"] = str(
             self.traceTypeBox.currentIndex())
+        self.projectSettings["DebugWait"] = from_bool(
+            self.debugWaitBox.isChecked())
 
     def setDefaultInterpreter(self):
-        if self.useVirtualEnvBox.isChecked():
+        use_venv = self.useVirtualEnvBox.isChecked()
+        self.installedPythonVersionBox.setEnabled(not use_venv)
+        if use_venv:
             from Extensions.python_paths import venv_python
             self.projectSettings["DefaultInterpreter"] = venv_python(
                 self.projectPathDict["venvdir"])
@@ -202,8 +256,7 @@ class SetRunParameters(QLabel):
                     self.installedPythonVersionBox.currentText()
             else:
                 self.projectSettings["DefaultInterpreter"] = 'None'
-        self.projectSettings["UseVirtualEnv"] = from_bool(
-            self.useVirtualEnvBox.isChecked())
+        self.projectSettings["UseVirtualEnv"] = from_bool(use_venv)
         self.projectSettings["DebugWait"] = from_bool(
             self.debugWaitBox.isChecked())
 

--- a/Extensions/EditorTabWidget.py
+++ b/Extensions/EditorTabWidget.py
@@ -95,13 +95,14 @@ class EditorTabWidget(QTabWidget):
         self.gotoLineWidget = GotoLineWidget(self)
 
         self.mainLayout = QVBoxLayout()
+        self.mainLayout.setSpacing(0)
         self.setLayout(self.mainLayout)
-        if self.useData.SETTINGS["UI"] == "Custom":
-            self.adjustToStyleSheet(True)
-        else:
-            self.adjustToStyleSheet(False)
+        self._customUiMargins = self.useData.SETTINGS["UI"] == "Custom"
+        self.adjustToStyleSheet(self._customUiMargins)
 
         self.topVBox = QVBoxLayout()
+        self.topVBox.setContentsMargins(0, 0, 0, 0)
+        self.topVBox.setSpacing(0)
         self.mainLayout.addLayout(self.topVBox)
 
         self.mainLayout.addStretch(1)
@@ -135,6 +136,8 @@ class EditorTabWidget(QTabWidget):
         self.tabSelectButton.setMenu(self.openedTabsMenu)
 
         self.setTabBar(self.tabBar)
+        # Re-measure top margin now that the real tab bar exists.
+        self.adjustToStyleSheet(self._customUiMargins)
         self.setAcceptDrops(True)
         self.setUsesScrollButtons(True)
         self.setCornerWidget(self.tabSelectButton)
@@ -150,17 +153,37 @@ class EditorTabWidget(QTabWidget):
         self.newFileMenu.addAction(self.newHtmlFileAct)
         self.newFileMenu.addAction(self.newCssFileAct)
 
+    def showEvent(self, event):
+        QTabWidget.showEvent(self, event)
+        # Tab bar height can settle after first show; keep sheets flush.
+        self.adjustToStyleSheet(getattr(self, "_customUiMargins", True))
+
     def resizeView(self, hview, vview):
         self.editorWindow.resizeView(hview, vview)
 
+    def _tab_bar_height(self):
+        # Instance attribute ``self.tabBar`` shadows QTabWidget.tabBar().
+        bar = self.__dict__.get("tabBar")
+        if bar is None:
+            bar = QTabWidget.tabBar(self)
+        if bar is None:
+            return 0
+        if bar.height() > 0:
+            return bar.height()
+        return max(0, bar.sizeHint().height())
+
     def adjustToStyleSheet(self, adjust):
+        self._customUiMargins = bool(adjust)
+        top = self._tab_bar_height()
         if adjust:
-            self.mainLayout.setContentsMargins(0, 22, 14, 12)
+            self.mainLayout.setContentsMargins(0, top, 14, 12)
         else:
-            self.mainLayout.setContentsMargins(0, 24, 25, 12)
+            self.mainLayout.setContentsMargins(0, top, 25, 12)
 
     def addToolWidget(self, widget):
         hbox = QHBoxLayout()
+        hbox.setContentsMargins(0, 0, 0, 0)
+        hbox.setSpacing(0)
         hbox.addStretch(1)
         hbox.addWidget(widget)
         self.topVBox.addLayout(hbox)
@@ -559,6 +582,8 @@ class EditorTabWidget(QTabWidget):
         for toolWidget in self.toolWidgetList:
             toolWidget.hide()
         widget.show()
+        widget.updateGeometry()
+        self.topVBox.activate()
 
     def showProjectConfiguration(self):
         self.showMe(self.configDialog)

--- a/Extensions/PathLineEdit.py
+++ b/Extensions/PathLineEdit.py
@@ -32,6 +32,20 @@ class PathLineEdit(QLineEdit):
         self.dirButton.clicked.connect(self.insertDirPath)
         hbox.addWidget(self.dirButton)
 
+    def sizeHint(self):
+        hint = QLineEdit.sizeHint(self)
+        lay = self.layout()
+        if lay is not None:
+            return hint.expandedTo(lay.sizeHint())
+        return hint
+
+    def minimumSizeHint(self):
+        hint = QLineEdit.minimumSizeHint(self)
+        lay = self.layout()
+        if lay is not None:
+            return hint.expandedTo(lay.minimumSize())
+        return hint
+
     def insertDirPath(self):
         directory = QFileDialog.getExistingDirectory(self, "", QDir.homePath())
         if directory:

--- a/Extensions/StyleSheet.py
+++ b/Extensions/StyleSheet.py
@@ -455,12 +455,34 @@ _MAIN_MENU_TEMPLATE = Template("""
 
 _TOOL_WIDGET_TEMPLATE = Template("""
         QLabel#containerLabel {
+            border-top: none;
             border-left: 1px solid $accent;
             border-right: 1px solid $accent;
             border-bottom: 1px solid $accent;
             background: $bg;
         }
         QLabel#toolWidgetNameLabel { font: 14px; color: $textDim; }
+        QLabel#toolWidgetSectionLabel {
+            font: bold 12px;
+            color: $textDim;
+            padding-top: 4px;
+        }
+        /* Combos inside pull-down sheets: full border, not header underlines. */
+        QLabel#containerLabel QComboBox {
+            border: 1px solid $border;
+            border-radius: 3px;
+            padding: 3px 6px;
+            min-height: 22px;
+            background: $inputBg;
+            color: $text;
+        }
+        QLabel#containerLabel QComboBox:focus {
+            border: 1px solid $accent;
+        }
+        QLabel#containerLabel QComboBox:disabled {
+            color: $textDim;
+            background: $panel;
+        }
         """)
 
 _VIEW_SWITCHER_TEMPLATE = Template("""

--- a/scripts/exercise_editor.py
+++ b/scripts/exercise_editor.py
@@ -128,6 +128,7 @@ def main():
     exercise_bookmarks(editor_window, etw)
     exercise_git_panel(editor_window)
     exercise_go_to_definition(editor_window, proj_path)
+    exercise_tool_sheet_alignment(editor_window)
 
     print("ALL OK")
 
@@ -652,6 +653,36 @@ def exercise_go_to_definition(editor_window, proj_path):
     for _ in range(10):
         app.processEvents()
     print("STEP go-to-definition OK")
+
+
+def exercise_tool_sheet_alignment(editor_window):
+    """Top pull-down sheets must sit flush under the tab bar (no gray gap)."""
+    etw = editor_window.editorTabWidget
+    etw.show()
+    etw.adjustToStyleSheet(etw.useData.SETTINGS.get("UI") == "Custom")
+    for _ in range(5):
+        app.processEvents()
+
+    sheet = etw.setRunParameters
+    etw.showMe(sheet)
+    for _ in range(5):
+        app.processEvents()
+
+    expected_top = etw._tab_bar_height()
+    top_margin = etw.mainLayout.contentsMargins().top()
+    sheet_top = sheet.geometry().top()
+    assert top_margin == expected_top, (
+        "top margin should equal tab bar height: margin={0} bar={1}".format(
+            top_margin, expected_top))
+    assert abs(sheet_top - top_margin) <= 2, (
+        "tool sheet not flush with tab bar: sheet_top={0} margin={1}".format(
+            sheet_top, top_margin))
+    assert sheet.height() >= sheet.layout().minimumSize().height() - 1, (
+        "tool sheet shorter than layout: height={0} min={1}".format(
+            sheet.height(), sheet.layout().minimumSize().height()))
+    sheet.hide()
+    print("STEP tool-sheet-alignment OK, top_margin:", top_margin,
+          "| sheet_top:", sheet_top, "| height:", sheet.height())
 
 
 if __name__ == "__main__":

--- a/tests/test_run_parameters_layout.py
+++ b/tests/test_run_parameters_layout.py
@@ -1,0 +1,98 @@
+"""SetRunParameters layout: sizing, args enablement, venv coupling."""
+
+import os
+import sys
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from PyQt6.QtWidgets import (  # noqa: E402
+    QApplication, QCheckBox, QComboBox, QLabel, QSpinBox,
+)
+
+from Extensions.BottomWidgets.RunWidget import SetRunParameters  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def app():
+    return QApplication.instance() or QApplication([])
+
+
+def _settings():
+    return {
+        "RunType": "Run",
+        "TraceType": "0",
+        "RunWithArguments": "False",
+        "RunArguments": "",
+        "ClearOutputWindowOnRun": "True",
+        "BufferSize": "900",
+        "RunInternal": "True",
+        "UseVirtualEnv": "False",
+        "DebugWait": "False",
+        "DefaultInterpreter": sys.executable,
+    }
+
+
+def test_pass_arguments_toggles_field(app):
+    use = type("U", (), {"SETTINGS": {"InstalledInterpreters": [sys.executable]}})()
+    sheet = SetRunParameters(_settings(), {"venvdir": "/tmp/venv"}, use)
+    assert not sheet.argumentsLine.isEnabled()
+    sheet.runWithArgsBox.setChecked(True)
+    assert sheet.argumentsLine.isEnabled()
+    assert sheet.projectSettings["RunWithArguments"] in (True, "True")
+
+
+def test_venv_disables_interpreter_combo(app):
+    use = type("U", (), {"SETTINGS": {"InstalledInterpreters": [sys.executable]}})()
+    sheet = SetRunParameters(_settings(), {"venvdir": "/tmp/venv"}, use)
+    assert sheet.installedPythonVersionBox.isEnabled()
+    sheet.useVirtualEnvBox.setChecked(True)
+    assert not sheet.installedPythonVersionBox.isEnabled()
+
+
+def test_section_labels_present(app):
+    use = type("U", (), {"SETTINGS": {"InstalledInterpreters": [sys.executable]}})()
+    sheet = SetRunParameters(_settings(), {"venvdir": "/tmp/venv"}, use)
+    labels = [
+        w.text()
+        for w in sheet.findChildren(QLabel)
+        if w.objectName() == "toolWidgetSectionLabel"
+    ]
+    assert labels == ["Run", "Console", "Interpreter"]
+
+
+def test_sheet_tall_enough_for_layout(app):
+    use = type("U", (), {"SETTINGS": {"InstalledInterpreters": [sys.executable]}})()
+    sheet = SetRunParameters(_settings(), {"venvdir": "/tmp/venv"}, use)
+    sheet.show()
+    app.processEvents()
+    assert sheet.height() >= sheet.layout().minimumSize().height()
+    assert sheet.sizeHint().height() >= sheet.layout().minimumSize().height()
+
+
+def test_no_control_overlaps(app):
+    use = type("U", (), {"SETTINGS": {"InstalledInterpreters": [sys.executable]}})()
+    sheet = SetRunParameters(_settings(), {"venvdir": "/tmp/venv"}, use)
+    sheet.show()
+    app.processEvents()
+
+    controls = [
+        w for w in (
+            list(sheet.findChildren(QLabel))
+            + list(sheet.findChildren(QComboBox))
+            + list(sheet.findChildren(QCheckBox))
+            + list(sheet.findChildren(QSpinBox))
+        )
+        if w is not sheet and w.isVisible() and w.geometry().isValid()
+    ]
+    for i, a in enumerate(controls):
+        for b in controls[i + 1:]:
+            if a.isAncestorOf(b) or b.isAncestorOf(a):
+                continue
+            assert not a.geometry().intersects(b.geometry()), (
+                f"{a.__class__.__name__}:{getattr(a, 'text', lambda: '')()} "
+                f"{a.geometry()} overlaps "
+                f"{b.__class__.__name__} {b.geometry()}"
+            )

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -174,3 +174,7 @@ def test_git_panel(session):
 
 def test_go_to_definition(session):
     smoke.exercise_go_to_definition(session[1], session[4])
+
+
+def test_tool_sheet_alignment(session):
+    smoke.exercise_tool_sheet_alignment(session[1])


### PR DESCRIPTION
## Summary
- Restructure Run Parameters into Run / Console / Interpreter sections with clearer rows
- Fix sheet height clipping (QLabel sizeHint ignored the layout)
- Flush pull-down tool sheets to the tab bar (real tab-bar height, zero overlay spacing)

## Test plan
- [x] Unit tests for layout/enablement (	ests/test_run_parameters_layout.py)
- [ ] Open Run Parameters: no clipped controls, flush under editor tabs
- [ ] Toggle Pass arguments / Use venv and confirm enablement


Made with [Cursor](https://cursor.com)